### PR TITLE
Fix ShellCheck warnings

### DIFF
--- a/fzfmenu_run
+++ b/fzfmenu_run
@@ -7,7 +7,7 @@
 # Depends on: find, fzfmenu
 
 allexecs() {
-  local IFS=:
+  IFS=:
   for path in $PATH; do
     find "$path" -type f,l -executable -printf '%f\n' 2>/dev/null
   done | sort | uniq

--- a/tmux-git-peek
+++ b/tmux-git-peek
@@ -8,7 +8,7 @@
 #
 # Depends on: tmux, git
 
-cd "$(tmux display-message -p -F '#{pane_current_path}')"
+cd "$(tmux display-message -p -F '#{pane_current_path}')" || exit 1
 
 [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != true ] && \
   exec tmux display-message -d 1000 "Not in a Git repository!"


### PR DESCRIPTION
Fix ShellCheck warnings by improving some scripts according to the suggestions given when analyzing them.