### PR TITLE
Use exec instead of nohup in fzfmenu_run

### DIFF
--- a/fzfmenu_run
+++ b/fzfmenu_run
@@ -15,4 +15,4 @@ allexecs() {
 
 choice="$(allexecs | fzfmenu +m --reverse --print-query 2>/dev/null | tail -1)"
 
-[ -n "$choice" ] && nohup $choice 2>/dev/null >/dev/null &
+[ -n "$choice" ] && exec $choice 2>/dev/null >/dev/null


### PR DESCRIPTION
This makes it so the process doesn't hang around even if /bin/sh is a link to
Bash. The nohup solution was something I came up with at some point since exec
wasn't doing the trick, but it seems the inverse holds true for Bash.

Go figure. This could change at some point. Works for me™.

Closes #7.
