### PR TITLE
Add script to update X11 clipboard

### DIFF
--- a/clip
+++ b/clip
@@ -4,11 +4,12 @@
 # contents of stdin itself and populates the X11 clipboard with it. The file
 # tool is used to get the mime-type for the data being copied.
 #
-# Depends on: xclip
+# Depends on: xclip, notify-send
 
 if [ -n "$1" ]; then
   mimetype="$(file -Lb --mime-type "$1")"
   xclip -r -selection c -t "$mimetype" < "$1"
+  notify-send "Updated clipboard!" "Contains data from: $1"
   exit $?
 fi
 
@@ -21,5 +22,6 @@ maybe_data_source="$(cat "$temp_filename")"
 mimetype="$(file -Lb --mime-type "$temp_filename")"
 
 xclip -r -selection c -t "$mimetype" < "$temp_filename"
+notify-send "Updated clipboard!" "Got data piped into it."
 
 rm "$temp_filename"

--- a/clip
+++ b/clip
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Takes input from a file given as argument, a file named on stdin, or the
+# contents of stdin itself and populates the X11 clipboard with it. The file
+# tool is used to get the mime-type for the data being copied.
+#
+# Depends on: xclip
+
+if [ -n "$1" ]; then
+  mimetype="$(file -Lb --mime-type "$1")"
+  xclip -r -selection c -t "$mimetype" < "$1"
+  exit $?
+fi
+
+temp_filename="$(mktemp)"
+cat /dev/stdin > "$temp_filename"
+
+maybe_data_source="$(cat "$temp_filename")"
+[ -r "$maybe_data_source" ] && cat "$maybe_data_source" > "$temp_filename"
+
+mimetype="$(file -Lb --mime-type "$temp_filename")"
+
+xclip -r -selection c -t "$mimetype" < "$temp_filename"
+
+rm "$temp_filename"


### PR DESCRIPTION
Add a script that puts data into the X11 clipboard in a smart way. If a filename
is given as the script's argument, it'll use that file. If none, the contents of
standard input will analyzed to see if they point to any other file, and if not,
they will end up in the clipboard themselves.
