### PR TITLE
Ignore error status codes from tmux popup in git-peek

### DIFF
--- a/tmux-git-peek
+++ b/tmux-git-peek
@@ -13,5 +13,5 @@ cd "$(tmux display-message -p -F '#{pane_current_path}')" || exit 1
 [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != true ] && \
   exec tmux display-message -d 1000 "Not in a Git repository!"
 
-exec tmux display-popup -E -w 65% -h 65% -d '#{pane_current_path}' \
-  git log --oneline --color --graph --decorate
+tmux display-popup -E -w 65% -h 65% -d '#{pane_current_path}' \
+  git log --oneline --color --graph --decorate || true


### PR DESCRIPTION
Disregard non-zero exit status codes from the tmux display-popup line.

Since I couldn't reproduce the error without running it through the script
itself, the call to exec was removed (what's another PID, eh?) and a "|| true"
was added to disregard any error exit codes from the tmux command.

Closes #6.
