### PR TITLE
Set the override_redirect bit and other options in fzfmenu

### DIFF
--- a/fzfmenu
+++ b/fzfmenu
@@ -10,5 +10,5 @@
 #
 # Depends on: st, fzf
 
-exec st -n 'fzfmenu' -c 'fzfmenu' -t 'fzfmenu' -g 120x25 \
-  -e sh -c "fzf --inline-info $* < /proc/$$/fd/0 > /proc/$$/fd/1"
+exec st -n 'fzfmenu' -c 'fzfmenu' -t 'fzfmenu' -g 120x25 -r -C \
+  -b 2 -B a54242 -e sh -c "fzf --inline-info $* < /proc/$$/fd/0 > /proc/$$/fd/1"


### PR DESCRIPTION
Set the override_redirect bit, center the window, draw a border and color the
border through the flags available in my patched version of st.

**BREAKING CHANGE**: with this commit, fzfmenu works only with a patched version
of st that includes the '-b', '-r', '-C' and '-B' flags. Refer to d3adb5/st on
GitHub for the patches.
