### PR TITLE
Prepend username to screenshot filename

### DIFF
--- a/screenshot
+++ b/screenshot
@@ -10,7 +10,7 @@
 #
 # Depends on: maim, notify-send
 
-img_path="${TMP_SCREENSHOT_PATH:-/dev/shm/screenshot.png}"
+img_path="${TMP_SCREENSHOT_PATH:-/dev/shm/$USER-screenshot.png}"
 
 if ! maim "$@" -u "$img_path"; then
 	notify-send "screenshot failed" "maim failed to take a screenshot"


### PR DESCRIPTION
Prepend the name of the user taking the screenshot to the file name. That way,
each user points to a different file and there is no realistic way permission
issues will arise from it.

Closes #12.
