### PR TITLE
fix(clip): use xclip's -i flag instead of redirect

### DIFF
--- a/clip
+++ b/clip
@@ -21,7 +21,7 @@ maybe_data_source="$(cat "$temp_filename")"
 
 mimetype="$(file -Lb --mime-type "$temp_filename")"
 
-xclip -r -selection c -t "$mimetype" < "$temp_filename"
+xclip -r -selection c -t "$mimetype" -i "$temp_filename"
 notify-send "Updated clipboard!" "Got data piped into it."
 
 rm "$temp_filename"


### PR DESCRIPTION
Use xclip's -i flag instead of redirecting the contents of the file to the process' standard input. It's been a long time since I actually made this change, and so I don't remember what the issue I was getting is.

Beautiful commit message, isn't it? Very explanatory. Should've created an issue on GitHub or any other issue tracker instead of just keeping it to myself. Oh well, what's done is done.
