### PR TITLE
Add run-on-ping script

### DIFF
--- a/run-on-ping
+++ b/run-on-ping
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# A script that takes a command and runs it when a given port is pinged with
+# netcat. The program relies on socat for listening to traffic locally, and
+# netcat or anything that is able to connect to the port and close the
+# connection.
+#
+# It'll listen on the port specified in the PINGCMD_PORT environment variable,
+# or on port 8989 if the variable is empty or not set.
+#
+# Dependencies: socat
+
+portToListenOn="${PINGCMD_PORT:-8989}"
+
+while socat - tcp4-listen:"$portToListenOn"; do
+  "$@"
+done


### PR DESCRIPTION
Add a script that continuously runs a given command if connections are being successfully closed on a given port. socat is used for listening for connections, and tools like netcat and anything else, really, can be used to close the connection.

This is being used as an alternative to a named pipe when running build and test commands on a different window while changing code with Neovim. As an example of usage, the makeprg variable in Neovim is set to "nc -z localhost 8989".
