### PR TITLE
fix: use pinentry-gtk instead of gtk-2

### DIFF
--- a/pinentry-select
+++ b/pinentry-select
@@ -6,7 +6,7 @@
 
 case "${PINENTRY_USER_DATA:-curses}" in
   gui|gtk)
-    exec /usr/bin/pinentry-gtk-2 "$@"
+    exec /usr/bin/pinentry-gtk "$@"
     ;;
 
   cli|curses)


### PR DESCRIPTION
There is no longer a pinentry-gtk-2 binary shipped with the pinentry
package on Arch Linux, so this had to be changed to allow scripts like
fzfpass to maintain a working pinentry program.
