### PR TITLE
fix(fzfmenu): do not keep parent process in fzfmenu_run

### DIFF
--- a/fzfmenu_run
+++ b/fzfmenu_run
@@ -15,4 +15,4 @@ allexecs() {
 
 choice="$(allexecs | fzfmenu +m --reverse --print-query 2>/dev/null | tail -1)"
 
-[ -n "$choice" ] && exec $choice 2>/dev/null >/dev/null
+[ -n "$choice" ] && nohup $choice 2>/dev/null >/dev/null &


### PR DESCRIPTION
Use a background nohup to ensure that the parent shell process is not
kept alive. For whatever reason the exec system call does not eliminate
the parent process on a standard Arch Linux installation.
