### PR TITLE
fix: use temporary files for fzfmenu

### DIFF
--- a/fzfmenu
+++ b/fzfmenu
@@ -10,5 +10,16 @@
 #
 # Depends on: st, fzf
 
-exec st -n 'fzfmenu' -c 'fzfmenu' -t 'fzfmenu' -g 120x25 -r -C \
-  -b 2 -B a54242 -e sh -c "fzf --inline-info $* < /proc/$$/fd/0 > /proc/$$/fd/1"
+menuOptions=$(mktemp)
+selection=$(mktemp)
+
+while read -r line; do
+  echo "$line" >> "$menuOptions"
+done
+
+st -n 'fzfmenu' -c 'fzfmenu' -t 'fzfmenu' -g 120x25 -r -C \
+  -b 2 -B a54242 -e sh -c "fzf --inline-info $* < '$menuOptions' > '$selection'"
+
+cat "$selection"
+
+rm -f "$menuOptions" "$selection"


### PR DESCRIPTION
Use temporary files for fzfmenu's input and output instead of trying to let an exec'd process take over stdin and stdout, as that seems to have been leading to a race condition in closing file descriptors.
